### PR TITLE
Update stack version to 1.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:latest
 MAINTAINER Sam Doshi <sam@metal-fish.co.uk>
 
-ENV STACK_VERSION 1.3.2
+ENV STACK_VERSION 1.6.3
 
 ENV STACK_DOWNLOAD_URL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64.tar.gz
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
In case it's necessary to add context, there's a particularly nasty error affecting older versions of stack: https://github.com/commercialhaskell/stack/issues/3686